### PR TITLE
Fix met2den import issues

### DIFF
--- a/solver/met2den.py
+++ b/solver/met2den.py
@@ -1,8 +1,11 @@
 import numpy as np
-from solver.tools import ricciS, ricciT, einT, einE
+from solver.tools.ricciS import ricciS2
+from solver.tools.ricciT import ricciT2
+from solver.tools.einT import einT2
+from solver.tools.einE import einE
 from solver.tools.c4Inv import c4Inv2
 
-def met2den(gl, delta=None):
+def met2den(gl, delta=None, units=None):
     """
     Coverts a Cartesian metric tensor to the corresponding energy density tensor using the Einstein Field Equations
     
@@ -22,20 +25,22 @@ def met2den(gl, delta=None):
     # Handle default input arguments
     if delta is None:
         delta = [1, 1, 1, 1]
+    if units is None:
+        units = [1, 1, 1]
     
     # Calculate metric tensor inverse
-    gu = c4Inv(gl_np)
+    gu = c4Inv2(gl_np)
     
     # Calculate the Ricci tensor
-    R_munu = ricciT(gu, gl_np, delta)
+    R_munu = ricciT2(gu, gl_np, delta)
     
     # Calculate the Ricci scalar
-    R = ricciS(R_munu, gu)
+    R = ricciS2(R_munu, gu)
     
     # Calculate Einstein tensor
-    E = einT(R_munu, R, gl_np)
+    E = einT2(R_munu, R, gl_np)
     
     # Calculate Energy density
-    energy_density = einE(E, gu)
+    energy_density = einE(E, gu, units)
     
     return energy_density

--- a/solver/tools/einE.py
+++ b/solver/tools/einE.py
@@ -1,5 +1,6 @@
 #Hey Heads Up!. The constants will need to be updated shortly to deal with quantum physics. While they are constants, they actually aren't. This is an assumption.
-#Called by met2den.py
+# Called by met2den.py
+from math import pi
 
 def einE(E, gu, units):
     # Constants


### PR DESCRIPTION
## Summary
- fix incorrect imports in `met2den`
- add optional `units` argument and use `c4Inv2`
- import `pi` constant in `einE`

## Testing
- `python -m py_compile analyticalEnergyTensor.py solver/met2den.py solver/tools/einE.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b2ce638c8325911aaab6c82d6c45