### PR TITLE
Add simulation engine module

### DIFF
--- a/simulation/engine.py
+++ b/simulation/engine.py
@@ -1,0 +1,56 @@
+try:
+    import sympy as sp
+except Exception:  # no sympy
+    sp = None
+
+try:
+    from analyticalEnergyTensor import analyticalEnergyTensor
+except Exception:
+    analyticalEnergyTensor = None
+
+try:
+    from solver.met2den import met2den
+except Exception:
+    met2den = None
+
+
+class SimulationEngine:
+    def __init__(self, metric_tensor, dt, duration, coords=None):
+        self.metric = metric_tensor
+        self.dt = dt
+        self.duration = duration
+        self.coords = coords
+        self.objects = []
+        self.time = 0.0
+        self.stress_energy = None
+
+    def add_object(self, obj):
+        self.objects.append(obj)
+
+    def _compute_stress_energy(self):
+        if sp is not None and isinstance(self.metric, getattr(sp, 'Matrix', ())):
+            if self.coords is not None and analyticalEnergyTensor is not None:
+                try:
+                    return analyticalEnergyTensor(self.metric, self.coords)
+                except Exception:
+                    return None
+        if met2den is not None:
+            try:
+                return met2den(self.metric)
+            except Exception:
+                return None
+        return None
+
+    def step(self):
+        self.stress_energy = self._compute_stress_energy()
+        for obj in self.objects:
+            if hasattr(obj, 'apply'):
+                self.metric = obj.apply(self.metric, self.dt)
+        self.time += self.dt
+        return self.metric
+
+    def run(self):
+        steps = int(self.duration / self.dt)
+        for _ in range(steps):
+            self.step()
+        return self.metric

--- a/simulation/tests/test_engine.py
+++ b/simulation/tests/test_engine.py
@@ -1,0 +1,26 @@
+import unittest
+
+from simulation.engine import SimulationEngine
+
+
+class DummyObject:
+    def apply(self, metric, dt):
+        metric[0][0] += dt
+        return metric
+
+
+class TestSimulationEngine(unittest.TestCase):
+    def test_step_updates_metric(self):
+        g = [[-1, 0, 0, 0],
+             [0, 1, 0, 0],
+             [0, 0, 1, 0],
+             [0, 0, 0, 1]]
+        engine = SimulationEngine(g, dt=0.1, duration=0.1)
+        engine.add_object(DummyObject())
+        initial = engine.metric[0][0]
+        engine.step()
+        self.assertAlmostEqual(engine.metric[0][0], initial + 0.1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `SimulationEngine` class to drive metric simulations
- handle missing optional deps gracefully when computing stress energy
- include basic unit test for the engine

## Testing
- `python -m unittest discover -s simulation/tests -v`


------
https://chatgpt.com/codex/tasks/task_e_684e6520cdb08325a7757f393a1fc7e4