### PR TITLE
Phase 1/2: CPU reference pipeline and experiment CLI

### DIFF
--- a/docs/PHASE_1_2_RELEASE.md
+++ b/docs/PHASE_1_2_RELEASE.md
@@ -1,0 +1,36 @@
+# Tensor Toolkit Phase 1/2 CPU Reference Release
+
+Version 0.2.0 intentionally limits scope to two objectives:
+
+1. Maintain one readable, float64 CPU reference path for `g_cov -> g_contra -> Gamma -> Riemann -> Ricci -> R -> Einstein -> T` using the documented `(-,+,+,+)` convention.
+2. Provide an installable command-line application for selecting and running built-in experiments.
+
+## Install and run
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+tensor-toolkit doctor
+tensor-toolkit list
+tensor-toolkit run minkowski
+tensor-toolkit run de-sitter --output results/de_sitter
+tensor-toolkit run alcubierre --output results/alcubierre
+```
+
+Running `tensor-toolkit` without arguments in an interactive terminal opens a basic experiment selector.
+
+## GPU status
+
+GPU execution is explicitly unsupported in 0.2.0. The previous `tryGPU` path used NumPy arrays and therefore did not constitute a GPU implementation. The supported backend is CPU/NumPy float64. A future GPU backend should be implemented separately and validated component-by-component against the CPU reference pathway before being enabled.
+
+## Output
+
+When `--output DIRECTORY` is supplied, Tensor Toolkit writes:
+
+- `result.npz`: compressed NumPy arrays for requested fields and coordinate axes.
+- `metadata.json`: metric name, coordinates, grid spacing and shape, units, backend, and field names.
+
+## Phase boundary
+
+This release does not add particle dynamics, classical mechanics, electromagnetism, 3+1 evolution, or matter backreaction. Those remain later phases after the reference GR path and experiment runtime are established.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensor-toolkit"
-version = "0.1.0"
-description = "Reference general-relativity tensor calculations and legacy Tensor Toolkit experiments"
+version = "0.2.0"
+description = "CPU reference general-relativity tensor calculations with a headless experiment runner"
 requires-python = ">=3.10"
 dependencies = ["numpy>=1.24"]
 
 [project.optional-dependencies]
 test = ["pytest>=7.4"]
+
+[project.scripts]
+tensor-toolkit = "tensor_toolkit.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tensor_toolkit/backends.py
+++ b/tensor_toolkit/backends.py
@@ -1,0 +1,20 @@
+"""Execution backend policy.
+
+Version 0.2 supports only the NumPy/CPU reference implementation. GPU execution is
+intentionally sidelined until a real, independently validated backend exists.
+"""
+SUPPORTED_BACKENDS = ("cpu",)
+
+
+def require_backend(name: str) -> str:
+    name = name.lower()
+    if name == "gpu":
+        raise NotImplementedError(
+            "GPU execution is not supported in Tensor Toolkit 0.2; use --backend cpu. "
+            "GPU support is reserved for a future validated backend."
+        )
+    if name not in SUPPORTED_BACKENDS:
+        raise ValueError(
+            f"unsupported backend {name!r}; supported: {', '.join(SUPPORTED_BACKENDS)}"
+        )
+    return name

--- a/tensor_toolkit/cli.py
+++ b/tensor_toolkit/cli.py
@@ -1,0 +1,86 @@
+"""Command-line entry point for Tensor Toolkit."""
+
+import argparse
+import sys
+from dataclasses import replace
+
+from tensor_toolkit.backends import require_backend
+from tensor_toolkit.experiment import run_experiment
+from tensor_toolkit.io import save_result
+from tensor_toolkit.registry import builtins, get_experiment
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tensor-toolkit",
+        description="Tensor Toolkit CPU reference GR experiment runner",
+    )
+    parser.add_argument("--version", action="version", version="tensor-toolkit 0.2.0")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("list", help="list built-in experiments")
+    run = sub.add_parser("run", help="run a built-in experiment")
+    run.add_argument("experiment", choices=sorted(builtins()))
+    run.add_argument("--output", default=None, help="directory for result.npz and metadata.json")
+    run.add_argument("--backend", default="cpu", choices=("cpu", "gpu"))
+    sub.add_parser("doctor", help="show supported execution capabilities")
+    return parser
+
+
+def _run(name: str, output: str | None, backend: str) -> int:
+    try:
+        require_backend(backend)
+    except (ValueError, NotImplementedError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    experiment = replace(get_experiment(name), backend=backend)
+    print(f"Running {name} on CPU...")
+    result = run_experiment(experiment)
+    for key, value in result.fields.items():
+        print(
+            f"  {key:14s} shape={value.shape} "
+            f"max|value|={float(abs(value).max()):.6g}"
+        )
+    if output:
+        print(f"Saved: {save_result(result, output)}")
+    return 0
+
+
+def _interactive() -> int:
+    names = sorted(builtins())
+    print("Tensor Toolkit 0.2.0\n")
+    for index, name in enumerate(names, 1):
+        print(f"{index}. {name}")
+    raw = input("Select experiment: ").strip()
+    try:
+        name = names[int(raw) - 1] if raw.isdigit() else raw
+    except (IndexError, ValueError):
+        raise SystemExit("invalid selection")
+    return _run(name, None, "cpu")
+
+
+def main(argv=None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        if sys.stdin.isatty():
+            return _interactive()
+        parser.print_help()
+        return 0
+    if args.command == "list":
+        for name, experiment in sorted(builtins().items()):
+            print(f"{name:12s} {experiment.metric.name}")
+        return 0
+    if args.command == "doctor":
+        print(
+            "Backend: CPU/NumPy float64 (supported)\n"
+            "GPU: future upgrade; explicitly unsupported in 0.2.0\n"
+            "Pipeline: metric -> inverse -> Christoffel -> Riemann -> "
+            "Ricci -> scalar -> Einstein -> stress-energy"
+        )
+        return 0
+    return _run(args.experiment, args.output, args.backend)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tensor_toolkit/experiment.py
+++ b/tensor_toolkit/experiment.py
@@ -1,4 +1,4 @@
-"""Headless experiment definition and execution for spacetime calculations."""
+"""Headless experiment definition and single-pass execution."""
 
 from __future__ import annotations
 
@@ -6,15 +6,16 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from tensor_toolkit.backends import require_backend
 from tensor_toolkit.metrics import Metric
-from tensor_toolkit.reference import (
+from tensor_toolkit.reference.geometry import (
     christoffel_symbols,
-    einstein_tensor,
+    einstein_from_ricci,
     inverse_metric,
-    ricci_scalar,
-    ricci_tensor,
-    riemann_tensor,
-    stress_energy_tensor,
+    ricci_from_riemann,
+    ricci_scalar_from_ricci,
+    riemann_from_christoffel,
+    stress_energy_from_einstein,
 )
 
 SUPPORTED_OUTPUTS = frozenset({
@@ -43,6 +44,7 @@ class Experiment:
     axes: tuple[Axis, Axis, Axis, Axis]
     outputs: frozenset[str] = field(default_factory=lambda: frozenset({"metric", "einstein"}))
     stress_energy_units: str = "geometrized"
+    backend: str = "cpu"
 
     def coordinates(self) -> tuple[np.ndarray, ...]:
         vectors = tuple(axis.values() for axis in self.axes)
@@ -62,8 +64,8 @@ class ExperimentResult:
     metadata: dict[str, object]
 
 
-
 def run_experiment(experiment: Experiment) -> ExperimentResult:
+    require_backend(experiment.backend)
     unknown = set(experiment.outputs) - SUPPORTED_OUTPUTS
     if unknown:
         raise ValueError(f"unsupported experiment outputs: {sorted(unknown)}")
@@ -74,23 +76,49 @@ def run_experiment(experiment: Experiment) -> ExperimentResult:
     metric = experiment.metric.evaluate(coordinate_grid)
     fields: dict[str, np.ndarray] = {}
 
+    def need(*names: str) -> bool:
+        return any(name in experiment.outputs for name in names)
+
     if "metric" in experiment.outputs:
         fields["metric"] = metric
+
+    inverse = inverse_metric(metric) if need(
+        "inverse_metric", "christoffel", "riemann", "ricci",
+        "ricci_scalar", "einstein", "stress_energy"
+    ) else None
     if "inverse_metric" in experiment.outputs:
-        fields["inverse_metric"] = inverse_metric(metric)
+        fields["inverse_metric"] = inverse
+
+    christoffel = christoffel_symbols(metric, spacings) if need(
+        "christoffel", "riemann", "ricci", "ricci_scalar", "einstein", "stress_energy"
+    ) else None
     if "christoffel" in experiment.outputs:
-        fields["christoffel"] = christoffel_symbols(metric, spacings)
+        fields["christoffel"] = christoffel
+
+    riemann = riemann_from_christoffel(christoffel, spacings) if need(
+        "riemann", "ricci", "ricci_scalar", "einstein", "stress_energy"
+    ) else None
     if "riemann" in experiment.outputs:
-        fields["riemann"] = riemann_tensor(metric, spacings)
+        fields["riemann"] = riemann
+
+    ricci = ricci_from_riemann(riemann) if need(
+        "ricci", "ricci_scalar", "einstein", "stress_energy"
+    ) else None
     if "ricci" in experiment.outputs:
-        fields["ricci"] = ricci_tensor(metric, spacings)
+        fields["ricci"] = ricci
+
+    scalar = ricci_scalar_from_ricci(metric, ricci) if need(
+        "ricci_scalar", "einstein", "stress_energy"
+    ) else None
     if "ricci_scalar" in experiment.outputs:
-        fields["ricci_scalar"] = ricci_scalar(metric, spacings)
+        fields["ricci_scalar"] = scalar
+
+    einstein = einstein_from_ricci(metric, ricci) if need("einstein", "stress_energy") else None
     if "einstein" in experiment.outputs:
-        fields["einstein"] = einstein_tensor(metric, spacings)
+        fields["einstein"] = einstein
     if "stress_energy" in experiment.outputs:
-        fields["stress_energy"] = stress_energy_tensor(
-            metric, spacings, units=experiment.stress_energy_units
+        fields["stress_energy"] = stress_energy_from_einstein(
+            einstein, units=experiment.stress_energy_units
         )
 
     return ExperimentResult(
@@ -102,6 +130,7 @@ def run_experiment(experiment: Experiment) -> ExperimentResult:
             "spacings": spacings,
             "shape": metric.shape[2:],
             "stress_energy_units": experiment.stress_energy_units,
+            "backend": "cpu",
         },
     )
 

--- a/tensor_toolkit/io.py
+++ b/tensor_toolkit/io.py
@@ -1,0 +1,27 @@
+"""Persist experiment results in a simple, inspectable format."""
+
+from pathlib import Path
+import json
+import numpy as np
+
+
+def save_result(result, path):
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    arrays = {f"field__{name}": value for name, value in result.fields.items()}
+    arrays.update({f"axis__{i}": value for i, value in enumerate(result.axis_values)})
+    np.savez_compressed(path / "result.npz", **arrays)
+    metadata = {
+        "metric_name": result.metric_name,
+        "coordinates": result.coordinates,
+        **result.metadata,
+        "fields": sorted(result.fields),
+    }
+    (path / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, default=list) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+__all__ = ["save_result"]

--- a/tensor_toolkit/reference/geometry.py
+++ b/tensor_toolkit/reference/geometry.py
@@ -9,7 +9,6 @@ from tensor_toolkit.validation import validate_metric, validate_spacings
 
 
 def inverse_metric(metric: np.ndarray) -> np.ndarray:
-    """Return ``g^{mu nu}`` for a metric stored as ``(4, 4, *grid)``."""
     g = validate_metric(metric)
     matrix_last = np.moveaxis(g, (0, 1), (-2, -1))
     try:
@@ -25,7 +24,6 @@ def _partial(field: np.ndarray, coordinate: int, spacings: tuple[float, ...], *,
 
 
 def metric_derivatives(metric: np.ndarray, spacings) -> np.ndarray:
-    """Return ``d_alpha g_{mu nu}`` as shape ``(4, 4, 4, *grid)``."""
     g = validate_metric(metric)
     grid_shape = g.shape[2:]
     dx = validate_spacings(spacings, grid_shape)
@@ -35,7 +33,6 @@ def metric_derivatives(metric: np.ndarray, spacings) -> np.ndarray:
 
 
 def christoffel_symbols(metric: np.ndarray, spacings) -> np.ndarray:
-    """Compute ``Gamma^rho_{mu nu}`` with shape ``(4, 4, 4, *grid)``."""
     g = validate_metric(metric)
     gu = inverse_metric(g)
     dg = metric_derivatives(g, spacings)
@@ -53,12 +50,9 @@ def christoffel_symbols(metric: np.ndarray, spacings) -> np.ndarray:
     return gamma
 
 
-def riemann_tensor(metric: np.ndarray, spacings) -> np.ndarray:
-    """Compute ``R^rho_{ sigma mu nu}`` using the documented sign convention."""
-    g = validate_metric(metric)
-    dx = validate_spacings(spacings, g.shape[2:])
-    gamma = christoffel_symbols(g, dx)
-    grid = g.shape[2:]
+def riemann_from_christoffel(gamma: np.ndarray, spacings) -> np.ndarray:
+    dx = tuple(float(x) for x in spacings)
+    grid = gamma.shape[3:]
     out = np.zeros((4, 4, 4, 4, *grid), dtype=np.float64)
     for rho in range(4):
         for sigma in range(4):
@@ -73,41 +67,51 @@ def riemann_tensor(metric: np.ndarray, spacings) -> np.ndarray:
     return out
 
 
+def riemann_tensor(metric: np.ndarray, spacings) -> np.ndarray:
+    return riemann_from_christoffel(christoffel_symbols(metric, spacings), spacings)
+
+
+def ricci_from_riemann(riemann: np.ndarray) -> np.ndarray:
+    return np.einsum("rsrn...->sn...", riemann)
+
+
 def ricci_tensor(metric: np.ndarray, spacings) -> np.ndarray:
-    """Compute ``R_{sigma nu} = R^rho_{ sigma rho nu}``."""
-    return np.einsum("rsrn...->sn...", riemann_tensor(metric, spacings))
+    return ricci_from_riemann(riemann_tensor(metric, spacings))
+
+
+def ricci_scalar_from_ricci(metric: np.ndarray, ricci: np.ndarray) -> np.ndarray:
+    return np.einsum("mn...,mn...->...", inverse_metric(metric), ricci)
 
 
 def ricci_scalar(metric: np.ndarray, spacings) -> np.ndarray:
-    """Compute ``R = g^{mu nu} R_{mu nu}``."""
-    gu = inverse_metric(metric)
-    ricci = ricci_tensor(metric, spacings)
-    return np.einsum("mn...,mn...->...", gu, ricci)
+    return ricci_scalar_from_ricci(metric, ricci_tensor(metric, spacings))
 
 
-def einstein_tensor(metric: np.ndarray, spacings) -> np.ndarray:
-    """Compute the covariant Einstein tensor ``G_{mu nu}``."""
+def einstein_from_ricci(metric: np.ndarray, ricci: np.ndarray) -> np.ndarray:
     g = validate_metric(metric)
-    ricci = ricci_tensor(g, spacings)
-    scalar = np.einsum("mn...,mn...->...", inverse_metric(g), ricci)
+    scalar = ricci_scalar_from_ricci(g, ricci)
     return ricci - 0.5 * g * scalar
 
 
-def stress_energy_tensor(metric: np.ndarray, spacings, *, units: str = "si") -> np.ndarray:
-    """Compute covariant ``T_{mu nu}`` from Einstein's equation with Lambda=0."""
+def einstein_tensor(metric: np.ndarray, spacings) -> np.ndarray:
+    return einstein_from_ricci(metric, ricci_tensor(metric, spacings))
+
+
+def stress_energy_from_einstein(einstein: np.ndarray, *, units: str = "si") -> np.ndarray:
     coupling = {"si": KAPPA_SI, "geometrized": KAPPA_GEOMETRIZED}.get(units)
     if coupling is None:
         raise ValueError("units must be 'si' or 'geometrized'")
-    return einstein_tensor(metric, spacings) / coupling
+    return einstein / coupling
+
+
+def stress_energy_tensor(metric: np.ndarray, spacings, *, units: str = "si") -> np.ndarray:
+    return stress_energy_from_einstein(einstein_tensor(metric, spacings), units=units)
 
 
 __all__ = [
-    "inverse_metric",
-    "metric_derivatives",
-    "christoffel_symbols",
-    "riemann_tensor",
-    "ricci_tensor",
-    "ricci_scalar",
-    "einstein_tensor",
+    "inverse_metric", "metric_derivatives", "christoffel_symbols",
+    "riemann_from_christoffel", "riemann_tensor", "ricci_from_riemann",
+    "ricci_tensor", "ricci_scalar_from_ricci", "ricci_scalar",
+    "einstein_from_ricci", "einstein_tensor", "stress_energy_from_einstein",
     "stress_energy_tensor",
 ]

--- a/tensor_toolkit/registry.py
+++ b/tensor_toolkit/registry.py
@@ -1,0 +1,33 @@
+"""Built-in Phase-2 experiment registry."""
+
+from tensor_toolkit.experiment import Axis, Experiment
+from tensor_toolkit.metrics import AlcubierreMetric, DeSitterFlatMetric, MinkowskiMetric
+
+
+def _axes(extent: float = 1.0, points: int = 3):
+    return tuple(Axis(-extent, extent, points) for _ in range(4))
+
+
+def builtins() -> dict[str, Experiment]:
+    common = frozenset({"metric", "einstein", "stress_energy"})
+    return {
+        "minkowski": Experiment(MinkowskiMetric(), _axes(), common),
+        "de-sitter": Experiment(DeSitterFlatMetric(hubble=0.1), _axes(), common),
+        "alcubierre": Experiment(
+            AlcubierreMetric(velocity=0.1, radius=1.0, sigma=2.0),
+            _axes(2.0, 5),
+            common,
+        ),
+    }
+
+
+def get_experiment(name: str) -> Experiment:
+    experiments = builtins()
+    if name not in experiments:
+        raise KeyError(
+            f"unknown experiment {name!r}; choose from: {', '.join(sorted(experiments))}"
+        )
+    return experiments[name]
+
+
+__all__ = ["builtins", "get_experiment"]

--- a/tensor_toolkit/validation.py
+++ b/tensor_toolkit/validation.py
@@ -18,6 +18,13 @@ def validate_metric(metric: np.ndarray, *, require_float64: bool = True, symmetr
         raise ValueError("metric contains NaN or infinite values")
     if not np.allclose(g, np.swapaxes(g, 0, 1), rtol=0.0, atol=symmetry_tol):
         raise ValueError("covariant metric must be symmetric in its tensor indices")
+
+    matrices = np.moveaxis(g, (0, 1), (-2, -1))
+    determinants = np.linalg.det(matrices)
+    if not np.all(np.isfinite(determinants)) or np.any(
+        np.isclose(determinants, 0.0, rtol=0.0, atol=1e-14)
+    ):
+        raise ValueError("metric is singular at one or more grid points")
     return g
 
 

--- a/tests/test_phase12_runner.py
+++ b/tests/test_phase12_runner.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from tensor_toolkit.backends import require_backend
+from tensor_toolkit.experiment import run_experiment
+from tensor_toolkit.registry import get_experiment
+
+
+def test_minkowski_pipeline_is_vacuum():
+    result = run_experiment(get_experiment("minkowski"))
+    assert np.max(np.abs(result.fields["einstein"])) < 1e-12
+    assert np.max(np.abs(result.fields["stress_energy"])) < 1e-12
+
+
+def test_gpu_is_explicitly_unsupported():
+    with pytest.raises(NotImplementedError):
+        require_backend("gpu")
+
+
+def test_result_records_cpu_backend():
+    result = run_experiment(get_experiment("minkowski"))
+    assert result.metadata["backend"] == "cpu"


### PR DESCRIPTION
Implements the Phase 1/2 boundary only.

- Adds `tensor-toolkit` console entry point and built-in experiment registry.
- Adds `list`, `run`, `doctor`, interactive selection, and NPZ/JSON result output.
- Makes CPU/NumPy float64 the only supported backend for this release.
- Explicitly rejects GPU requests until a real validated GPU backend exists.
- Refactors experiment execution into a single forward GR pipeline so downstream outputs reuse the same Christoffel/Riemann/Ricci calculation instead of recomputing it.
- Adds singular-metric validation.
- Adds tests for Minkowski vacuum, CPU backend metadata, and explicit GPU rejection.
- Documents the Phase 1/2 release boundary.

Local package smoke tests passed for Minkowski, de Sitter, and Alcubierre; Minkowski returns zero Einstein and stress-energy tensors on the reference grid.